### PR TITLE
Update minimum CMake version to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 project(tinycolormap CXX)
 set(CMAKE_CXX_STANDARD 11)


### PR DESCRIPTION
Configuring currently yields the warning
```
CMake Deprecation Warning at /Volumes/SamsungUSB/devel/danguitardaw/cmake-build-debug/_deps/tinycolormap-src/CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.
```
This commit should fix that!